### PR TITLE
Update ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-# BNC Chain Go SDK
+# BNB Chain Go SDK
 
 The Binance Chain GO SDK provides a thin wrapper around the BNC Chain API for readonly endpoints, in addition to creating and submitting different transactions.
 It includes the following core components:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,11 +3,11 @@
 The BNB Beacon Chain GO SDK provides a thin wrapper around the BNB Beacon Chain API for readonly endpoints, in addition to creating and submitting different transactions.
 It includes the following core components:
 
-* **client** - implementations of Binance Chain transaction types and query, such as for transfers and trading.
+* **client** - implementations of BNB Beacon Chain transaction types and query, such as for transfers and trading.
 * **common** - core cryptographic functions, uuid functions and other useful functions.
 * **e2e** - end-to-end test package for go-sdk developer. For common users, it is also a good reference to use go-sdk. 
 * **keys** - implement `KeyManage` to manage private key and accounts.
-* **types** - core type of Binance Chain, such as `coin`, `account`, `tx` and `msg`.
+* **types** - core type of BNB Beacon Chain, such as `coin`, `account`, `tx` and `msg`.
 
 ## Disclaimer
 **This branch is under active development, all subject to potential future change without notification and not ready for production use. The code and security audit have not been fully completed and not ready for any bug bounty.**

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
-# BNB Chain Go SDK
+# BNB Beacon Chain Go SDK
 
-The Binance Chain GO SDK provides a thin wrapper around the BNB Chain API for readonly endpoints, in addition to creating and submitting different transactions.
+The BNB Beacon Chain GO SDK provides a thin wrapper around the BNB Beacon Chain API for readonly endpoints, in addition to creating and submitting different transactions.
 It includes the following core components:
 
 * **client** - implementations of Binance Chain transaction types and query, such as for transfers and trading.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 # BNB Chain Go SDK
 
-The Binance Chain GO SDK provides a thin wrapper around the BNC Chain API for readonly endpoints, in addition to creating and submitting different transactions.
+The Binance Chain GO SDK provides a thin wrapper around the BNB Chain API for readonly endpoints, in addition to creating and submitting different transactions.
 It includes the following core components:
 
 * **client** - implementations of Binance Chain transaction types and query, such as for transfers and trading.


### PR DESCRIPTION
was this a typo? BNB Chain has a different meaning since Binance rebrand 'BNB Chain', it is necessary to specify which chain this SDK belongs to.